### PR TITLE
Index specific links

### DIFF
--- a/lib/recommended_links/indexer.rb
+++ b/lib/recommended_links/indexer.rb
@@ -26,7 +26,11 @@ module RecommendedLinks
     def remove(deleted_links)
       @logger.info "Deleting #{deleted_links.size} links..."
       deleted_links.each do |deleted_link|
-        Rummageable.delete(deleted_link)
+        if deleted_link.search_index.nil?
+          Rummageable.delete(deleted_link.url)
+        else
+          Rummageable.delete(deleted_link.url, "/#{deleted_link.search_index}")
+        end
       end
       @logger.info "Links deleted"
     end

--- a/lib/recommended_links/indexer.rb
+++ b/lib/recommended_links/indexer.rb
@@ -10,13 +10,21 @@ module RecommendedLinks
       @logger = logger
     end
 
+    def DEFAULT_ALIAS
+      "DEFAULT_INDEX"
+    end
+
     def index(recommended_links)
       @logger.info "Indexing #{recommended_links.size} links..."
+      to_index = {}
       recommended_links.each do |link|
-        if link.search_index.nil?
-          Rummageable.index(link.to_index)
+        (to_index[link.search_index || self.DEFAULT_ALIAS] ||= []) << link
+      end
+      to_index.each do |index, links|
+        if index == self.DEFAULT_ALIAS
+          Rummageable.index(links.map { |l| l.to_index })
         else
-          Rummageable.index(link.to_index, "/#{link.search_index}")
+          Rummageable.index(links.map { |l| l.to_index }, "/#{index}")
         end
       end
 

--- a/lib/recommended_links/indexer.rb
+++ b/lib/recommended_links/indexer.rb
@@ -12,19 +12,15 @@ module RecommendedLinks
 
     def index(recommended_links)
       @logger.info "Indexing #{recommended_links.size} links..."
-      Rummageable.index(recommended_links.map { |l| for_indexing(l) })
-      @logger.info "Recommended links indexed"
-    end
+      recommended_links.each do |link|
+        if link.search_index.nil?
+          Rummageable.index(link.to_index)
+        else
+          Rummageable.index(link.to_index, link.search_index)
+        end
+      end
 
-    def for_indexing(recommended_link)
-      {
-        "title" => recommended_link.title,
-        "description" => recommended_link.description,
-        "format" => recommended_link.format,
-        "link" => recommended_link.url,
-        "indexable_content" => recommended_link.match_phrases.join(", "),
-        "section" => recommended_link.section
-      }
+      @logger.info "Recommended links indexed"
     end
 
     def remove(deleted_links)

--- a/lib/recommended_links/indexer.rb
+++ b/lib/recommended_links/indexer.rb
@@ -10,21 +10,14 @@ module RecommendedLinks
       @logger = logger
     end
 
-    def DEFAULT_ALIAS
-      "DEFAULT_INDEX"
-    end
-
     def index(recommended_links)
       @logger.info "Indexing #{recommended_links.size} links..."
-      to_index = {}
-      recommended_links.each do |link|
-        (to_index[link.search_index || self.DEFAULT_ALIAS] ||= []) << link
-      end
+      to_index = recommended_links.group_by { |link| link.search_index || :default }
       to_index.each do |index, links|
-        if index == self.DEFAULT_ALIAS
-          Rummageable.index(links.map { |l| l.to_index })
+        if index == :default
+          Rummageable.index(links.map(&:to_index))
         else
-          Rummageable.index(links.map { |l| l.to_index }, "/#{index}")
+          Rummageable.index(links.map(&:to_index), "/#{index}")
         end
       end
 

--- a/lib/recommended_links/indexer.rb
+++ b/lib/recommended_links/indexer.rb
@@ -16,7 +16,7 @@ module RecommendedLinks
         if link.search_index.nil?
           Rummageable.index(link.to_index)
         else
-          Rummageable.index(link.to_index, link.search_index)
+          Rummageable.index(link.to_index, "/#{link.search_index}")
         end
       end
 

--- a/lib/recommended_links/parser.rb
+++ b/lib/recommended_links/parser.rb
@@ -29,7 +29,7 @@ module RecommendedLinks
       @links << RecommendedLink.new(
         h["title"], h["text"], h["link"],
         parse_match_phrases(h["keywords"]),
-        @type, h["section"]
+        @type, h["section"], h["search index"]
       )
     end
 

--- a/lib/recommended_links/parser.rb
+++ b/lib/recommended_links/parser.rb
@@ -48,7 +48,9 @@ module RecommendedLinks
     end
 
     def parse_row(h)
-      @links << h["link"]
+      @links << DeletedLink.new(
+        h["link"], h["search index"]
+      )
     end
   end
 end

--- a/lib/recommended_links/recommended_link.rb
+++ b/lib/recommended_links/recommended_link.rb
@@ -11,4 +11,7 @@ module RecommendedLinks
       }
     end
   end
+
+  class DeletedLink < Struct.new(:url, :search_index)
+  end
 end

--- a/lib/recommended_links/recommended_link.rb
+++ b/lib/recommended_links/recommended_link.rb
@@ -1,3 +1,14 @@
 module RecommendedLinks
-  RecommendedLink = Struct.new(:title, :description, :url, :match_phrases, :format, :section)
+  class RecommendedLink < Struct.new(:title, :description, :url, :match_phrases, :format, :section, :search_index)
+    def to_index
+      {
+        "title"             => title,
+        "description"       => description,
+        "format"            => format,
+        "link"              => url,
+        "indexable_content" => match_phrases.join(", "),
+        "section"           => section
+      }
+    end
+  end
 end

--- a/test/acceptance/rake_task_test.rb
+++ b/test/acceptance/rake_task_test.rb
@@ -13,8 +13,11 @@ module RecommendedLinks
         ["care homes", "old people's homes", "nursing homes", "sheltered housing"],
         "recommended-link", "This is a section"
       )
+      expected_deleted_link = DeletedLink.new(
+        "http://delete.me/some/page.html"
+      )
       indexer.expects(:index).with([expected_recommended_link])
-      indexer.expects(:remove).with(["http://delete.me/some/page.html"])
+      indexer.expects(:remove).with([expected_deleted_link])
 
       data_path = File.expand_path("../../fixtures/data", __FILE__)
       IndexingTask.new(data_path).run(indexer)

--- a/test/unit/indexer_test.rb
+++ b/test/unit/indexer_test.rb
@@ -38,11 +38,11 @@ module RecommendedLinks
     end
 
     test "Can remove links" do
-      deleted = ["http://delete.me/1", "http://delete.me/2"]
+      deleted = [DeletedLink.new("http://delete.me/1"), DeletedLink.new("http://delete.me/2")]
 
       s = sequence('deletion')
-      Rummageable.expects(:delete).with(deleted[0]).in_sequence(s)
-      Rummageable.expects(:delete).with(deleted[1]).in_sequence(s)
+      Rummageable.expects(:delete).with("http://delete.me/1").in_sequence(s)
+      Rummageable.expects(:delete).with("http://delete.me/2").in_sequence(s)
 
       Indexer.new.remove(deleted)
     end
@@ -66,6 +66,16 @@ module RecommendedLinks
         }, '/test-index')
 
       Indexer.new.index([recommended_link])
+    end
+
+    test "Can remove links from different indexes" do
+      deleted_link = DeletedLink.new(
+        "http://example.com/delete-me",
+        "test-index"
+        )
+      Rummageable.expects(:delete).with("http://example.com/delete-me", '/test-index')
+
+      Indexer.new.remove([deleted_link])
     end
 
   end

--- a/test/unit/indexer_test.rb
+++ b/test/unit/indexer_test.rb
@@ -12,42 +12,61 @@ module RecommendedLinks
         ["care homes", "old people's homes", "nursing homes", "sheltered housing"],
         "recommended-link", "Business"
       )
-      Rummageable.expects(:index).with([{
+      Rummageable.expects(:index).with({
           "title" => recommended_link.title,
           "description" => recommended_link.description,
           "format" => recommended_link.format,
           "link" => recommended_link.url,
           "indexable_content" => recommended_link.match_phrases.join(", "),
           "section" => recommended_link.section
-        }]
+        }
       )
-      
+
       Indexer.new.index([recommended_link])
     end
-    
+
     test "Indexing multiple recommended links adds them all using rummager" do
       recommended_links = [
         RecommendedLink.new("First","","",[]),
         RecommendedLink.new("Second","","",[])
       ]
-        
-      Rummageable.expects(:index).with do |links|
-        return false unless links.map {|l| l['title']} == %w{First Second}
-        links.first.keys == %w{title description format link indexable_content section}
-      end
-      
+
+      Rummageable.expects(:index).with(recommended_links[0].to_index)
+      Rummageable.expects(:index).with(recommended_links[1].to_index)
+
       Indexer.new.index(recommended_links)
     end
-    
+
     test "Can remove links" do
       deleted = ["http://delete.me/1", "http://delete.me/2"]
 
       s = sequence('deletion')
       Rummageable.expects(:delete).with(deleted[0]).in_sequence(s)
       Rummageable.expects(:delete).with(deleted[1]).in_sequence(s)
-      
+
       Indexer.new.remove(deleted)
     end
-    
+
+    test "Can add links to different indexes" do
+      recommended_link = RecommendedLink.new(
+        "Care homes",
+        "Find a care home and other residential housing on the NHS Choices website",
+        "http://www.nhs.uk/CarersDirect/guide/practicalsupport/Pages/Carehomes.aspx",
+        ["care homes", "old people's homes", "nursing homes", "sheltered housing"],
+        "recommended-link", "Business", "test-index"
+      )
+
+      Rummageable.expects(:index).with({
+          "title" => recommended_link.title,
+          "description" => recommended_link.description,
+          "format" => recommended_link.format,
+          "link" => recommended_link.url,
+          "indexable_content" => recommended_link.match_phrases.join(", "),
+          "section" => recommended_link.section
+        }, 'test-index')
+
+      Indexer.new.index([recommended_link])
+    end
+
   end
 end

--- a/test/unit/indexer_test.rb
+++ b/test/unit/indexer_test.rb
@@ -63,7 +63,7 @@ module RecommendedLinks
           "link" => recommended_link.url,
           "indexable_content" => recommended_link.match_phrases.join(", "),
           "section" => recommended_link.section
-        }, 'test-index')
+        }, '/test-index')
 
       Indexer.new.index([recommended_link])
     end

--- a/test/unit/indexer_test.rb
+++ b/test/unit/indexer_test.rb
@@ -12,15 +12,14 @@ module RecommendedLinks
         ["care homes", "old people's homes", "nursing homes", "sheltered housing"],
         "recommended-link", "Business"
       )
-      Rummageable.expects(:index).with({
+      Rummageable.expects(:index).with([{
           "title" => recommended_link.title,
           "description" => recommended_link.description,
           "format" => recommended_link.format,
           "link" => recommended_link.url,
           "indexable_content" => recommended_link.match_phrases.join(", "),
           "section" => recommended_link.section
-        }
-      )
+        }])
 
       Indexer.new.index([recommended_link])
     end
@@ -31,8 +30,7 @@ module RecommendedLinks
         RecommendedLink.new("Second","","",[])
       ]
 
-      Rummageable.expects(:index).with(recommended_links[0].to_index)
-      Rummageable.expects(:index).with(recommended_links[1].to_index)
+      Rummageable.expects(:index).with(recommended_links.map { |l| l.to_index })
 
       Indexer.new.index(recommended_links)
     end
@@ -56,14 +54,14 @@ module RecommendedLinks
         "recommended-link", "Business", "test-index"
       )
 
-      Rummageable.expects(:index).with({
+      Rummageable.expects(:index).with([{
           "title" => recommended_link.title,
           "description" => recommended_link.description,
           "format" => recommended_link.format,
           "link" => recommended_link.url,
           "indexable_content" => recommended_link.match_phrases.join(", "),
           "section" => recommended_link.section
-        }, '/test-index')
+        }], '/test-index')
 
       Indexer.new.index([recommended_link])
     end

--- a/test/unit/parser_test.rb
+++ b/test/unit/parser_test.rb
@@ -53,7 +53,7 @@ module RecommendedLinks
     test "Can parse a deleted links file" do
       deleted_links = DeletedLinksParser.new(deleted_links_fixture_file).links
 
-      assert_equal ['http://delete.me/some/page.html'], deleted_links
+      assert_equal 'http://delete.me/some/page.html', deleted_links.first.url
     end
 
     test "Can parse the included data file" do


### PR DESCRIPTION
This allows an extra column of "Search index" to be added at the end of any add/remove line.

This index specifies a Rummager index that this link should be added to/removed from, as the default Rummager behaviour is to add/remove on the primary index only.

This behaviour is fully backwards compatible and requires no change to existing data or editorial behaviour.

See https://www.pivotaltracker.com/story/show/40018669 for more information.
