### PR TITLE
Register urls with external link tracker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'http://rubygems.org'
 gem 'plek', '1.3.1'
 gem 'rummageable', "0.6.1"
 gem 'rake', '0.9.2'
+gem 'gds-api-adapters', '10.2.0'
 
 group :test do
   gem 'mocha', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,23 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    PriorityQueue (0.1.2)
     ansi (1.4.1)
+    gds-api-adapters (10.2.0)
+      link_header
+      lrucache (~> 0.1.1)
+      null_logger
+      plek
+      rest-client (~> 1.6.3)
     json (1.7.5)
+    link_header (0.0.8)
+    lrucache (0.1.4)
+      PriorityQueue (~> 0.1.2)
     metaclass (0.0.1)
     mime-types (1.19)
     mocha (0.10.0)
       metaclass (~> 0.0.1)
+    null_logger (0.0.1)
     plek (1.3.1)
     rake (0.9.2)
     rest-client (1.6.7)
@@ -24,6 +35,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  gds-api-adapters (= 10.2.0)
   mocha
   plek (= 1.3.1)
   rake (= 0.9.2)

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@ require 'rake'
 require 'rake/testtask'
 
 load "lib/tasks/index.rake"
+load "lib/tasks/deploy_links.rake"
 task :default => [:test]
 
 desc "Run all tests"

--- a/lib/recommended_links/external_link_registerer.rb
+++ b/lib/recommended_links/external_link_registerer.rb
@@ -1,0 +1,31 @@
+require 'gds_api/external_link_tracker'
+require 'logger'
+
+module RecommendedLinks
+  class ExternalLinkRegisterer
+    attr_reader :logger
+
+    def initialize(logger = default_logger)
+      @logger = logger
+    end
+
+    def register_links(links)
+      logger.info "Registering #{links.count} links with external link tracker..."
+
+      links.each do |link|
+        api.add_external_link(link.url)
+      end
+
+      logger.info 'Recommend links registered'
+    end
+
+  private
+    def api
+      @api ||= GdsApi::ExternalLinkTracker.new(Plek.current.find('api-external-link-tracker'))
+    end
+
+    def default_logger
+      Logger.new('/dev/null')
+    end
+  end
+end

--- a/lib/recommended_links/indexing_task.rb
+++ b/lib/recommended_links/indexing_task.rb
@@ -8,14 +8,19 @@ module RecommendedLinks
 
     def initialize(data_path, options = {})
       @data_path = data_path
-      @indexer = options.fetch(:indexer, RecommendedLinks::Indexer.new)
-      @external_link_registerer = options.fetch(:external_link_registerer, RecommendedLinks::ExternalLinkRegisterer.new)
+      @indexer = options[:indexer]
+      @external_link_registerer = options[:external_link_registerer]
     end
 
     def run
-      indexer.index(recommended_links)
-      indexer.remove(deleted_links)
-      external_link_registerer.register_links(recommended_links)
+      if indexer
+        indexer.index(recommended_links)
+        indexer.remove(deleted_links)
+      end
+
+      if external_link_registerer
+        external_link_registerer.register_links(recommended_links)
+      end
     end
 
   private

--- a/lib/recommended_links/indexing_task.rb
+++ b/lib/recommended_links/indexing_task.rb
@@ -1,18 +1,21 @@
 require_relative "./indexer"
 require_relative "./parser"
+require_relative "./external_link_registerer"
 
 module RecommendedLinks
   class IndexingTask
-    attr_reader :data_path, :indexer
+    attr_reader :data_path, :indexer, :external_link_registerer
 
     def initialize(data_path, options = {})
       @data_path = data_path
       @indexer = options.fetch(:indexer, RecommendedLinks::Indexer.new)
+      @external_link_registerer = options.fetch(:external_link_registerer, RecommendedLinks::ExternalLinkRegisterer.new)
     end
 
     def run
       indexer.index(recommended_links)
       indexer.remove(deleted_links)
+      external_link_registerer.register_links(recommended_links)
     end
 
   private

--- a/lib/recommended_links/indexing_task.rb
+++ b/lib/recommended_links/indexing_task.rb
@@ -3,13 +3,14 @@ require_relative "./parser"
 
 module RecommendedLinks
   class IndexingTask
-    attr_reader :data_path
+    attr_reader :data_path, :indexer
 
-    def initialize(data_path)
+    def initialize(data_path, options = {})
       @data_path = data_path
+      @indexer = options.fetch(:indexer, RecommendedLinks::Indexer.new)
     end
 
-    def run(indexer = RecommendedLinks::Indexer.new)
+    def run
       indexer.index(recommended_links)
       indexer.remove(deleted_links)
     end

--- a/lib/tasks/deploy_links.rake
+++ b/lib/tasks/deploy_links.rake
@@ -1,0 +1,19 @@
+require "logger"
+require_relative "../recommended_links/indexing_task"
+
+desc "Deploy the recommended links to rummager and external link tracker"
+task :deploy_links do
+  logger = Logger.new(Rake.verbose ? STDERR : "/dev/null")
+  logger.formatter = Proc.new do |severity, datetime, progname, msg|
+    "[#{severity}] #{msg}\n"
+  end
+
+  data_path = File.expand_path("../../data", File.dirname(__FILE__))
+
+  indexer = RecommendedLinks::Indexer.new(logger)
+  registerer = RecommendedLinks::ExternalLinkRegisterer.new(logger)
+
+  RecommendedLinks::IndexingTask.new(data_path,
+                                     indexer: indexer,
+                                     external_link_registerer: registerer).run
+end

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -10,6 +10,6 @@ namespace :rummager do
     end
     data_path = File.expand_path("../../data", File.dirname(__FILE__))
     indexer = RecommendedLinks::Indexer.new(logger)
-    RecommendedLinks::IndexingTask.new(data_path).run(indexer)
+    RecommendedLinks::IndexingTask.new(data_path, indexer: indexer).run
   end
 end

--- a/test/acceptance/rake_task_test.rb
+++ b/test/acceptance/rake_task_test.rb
@@ -5,6 +5,7 @@ module RecommendedLinks
   class RakeTaskTest < Test::Unit::TestCase
     test "rake rummager:index parses" do
       indexer = stub_everything("Indexer")
+      external_link_registerer = stub_everything("ExternalLinkRegisterer")
 
       expected_recommended_link = RecommendedLink.new(
         "Care homes",
@@ -18,9 +19,13 @@ module RecommendedLinks
       )
       indexer.expects(:index).with([expected_recommended_link])
       indexer.expects(:remove).with([expected_deleted_link])
+      external_link_registerer.expects(:register_links)
+                              .with([expected_recommended_link])
 
       data_path = File.expand_path("../../fixtures/data", __FILE__)
-      IndexingTask.new(data_path, indexer: indexer).run
+      IndexingTask.new(data_path,
+                       indexer: indexer,
+                       external_link_registerer: external_link_registerer).run
     end
 
     def teardown

--- a/test/acceptance/rake_task_test.rb
+++ b/test/acceptance/rake_task_test.rb
@@ -20,7 +20,7 @@ module RecommendedLinks
       indexer.expects(:remove).with([expected_deleted_link])
 
       data_path = File.expand_path("../../fixtures/data", __FILE__)
-      IndexingTask.new(data_path).run(indexer)
+      IndexingTask.new(data_path, indexer: indexer).run
     end
 
     def teardown

--- a/test/unit/external_link_registerer_test.rb
+++ b/test/unit/external_link_registerer_test.rb
@@ -1,0 +1,35 @@
+require 'gds_api/external_link_tracker'
+require_relative "../test_helper"
+require_relative "../../lib/recommended_links/external_link_registerer"
+
+module RecommendedLinks
+  class ExternalLinkRegistererTest < Test::Unit::TestCase
+    test "#register sends links to the external link tracker" do
+      care_homes_url = "http://www.nhs.uk/CarersDirect/guide/practicalsupport/Pages/Carehomes.aspx"
+      care_homes = RecommendedLink.new(
+        "Care homes",
+        "Find a care home and other residential housing on the NHS Choices website",
+        care_homes_url,
+        ["care homes", "old people's homes", "nursing homes", "sheltered housing"],
+      )
+
+      nhs_choices_url = "http://www.nhs.uk/"
+      nhs_choices = RecommendedLink.new(
+        "NHS Choices",
+        "Information from the National Health Service on conditions, treatments, local services and healthy living",
+        nhs_choices_url,
+        ["nhs", "health"],
+      )
+
+      GdsApi::ExternalLinkTracker.any_instance
+                                 .expects(:add_external_link)
+                                 .with(care_homes_url)
+
+      GdsApi::ExternalLinkTracker.any_instance
+                                 .expects(:add_external_link)
+                                 .with(nhs_choices_url)
+
+      ExternalLinkRegisterer.new.register_links([care_homes, nhs_choices])
+    end
+  end
+end


### PR DESCRIPTION
Add a new `deploy_links` rake task which both indexes links in rummager and registers them with the external link tracker
- [x] Test this on preview before merging
