### PR TITLE
Fix removal of building regulation results

### DIFF
--- a/data/remove/deleted-links.csv
+++ b/data/remove/deleted-links.csv
@@ -84,7 +84,7 @@ http://www.victimsupport.org/
 http://www.homebuy.co.uk/
 http://www.hmrc.gov.uk/payerti/
 https://www.gov.uk/bailiffchanges
-https://www.gov.uk/planning-applications-called-in-decisions-and-recovered-appeals
-https://www.gov.uk/building-regulations-appeals--6
-https://www.gov.uk/building-regulations-determinations
-https://www.gov.uk/building-regulations-divisional-circular-letters
+https://www.gov.uk/planning-applications-called-in-decisions-and-recovered-appeals,government
+https://www.gov.uk/building-regulations-appeals--6,government
+https://www.gov.uk/building-regulations-determinations,government
+https://www.gov.uk/building-regulations-divisional-circular-letters,government


### PR DESCRIPTION
The building regulation documents (and the planning applications
document) were indexed to the government index, so we need to specify
that when removing them.

(I hadn't actually realised we ever put recommended links in an index
other than mainstream.  Learn something new every day.)
