### PR TITLE
Upgrade rummageable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'http://rubygems.org'
 
 gem 'plek', '1.3.1'
-gem 'rummageable', "0.6.1"
+gem 'rummageable', "1.2.0"
 gem 'rake', '0.9.2'
 gem 'gds-api-adapters', '10.2.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,6 @@ GEM
       null_logger
       plek
       rest-client (~> 1.6.3)
-    json (1.8.1)
     link_header (0.0.8)
     lrucache (0.1.4)
       PriorityQueue (~> 0.1.2)
@@ -17,14 +16,15 @@ GEM
     mime-types (1.19)
     mocha (0.10.0)
       metaclass (~> 0.0.1)
+    multi_json (1.11.1)
     null_logger (0.0.1)
     plek (1.3.1)
     rake (0.9.2)
     rest-client (1.6.7)
       mime-types (>= 1.16)
-    rummageable (0.6.1)
-      json
-      plek (>= 0.5.0)
+    rummageable (1.2.0)
+      multi_json
+      null_logger
       rest-client
     shoulda (2.11.3)
     test-unit (2.4.3)
@@ -39,7 +39,7 @@ DEPENDENCIES
   mocha
   plek (= 1.3.1)
   rake (= 0.9.2)
-  rummageable (= 0.6.1)
+  rummageable (= 1.2.0)
   shoulda (~> 2.11.3)
   test-unit
   turn

--- a/test/unit/indexer_test.rb
+++ b/test/unit/indexer_test.rb
@@ -12,7 +12,9 @@ module RecommendedLinks
         ["care homes", "old people's homes", "nursing homes", "sheltered housing"],
         "recommended-link", "Business"
       )
-      Rummageable.expects(:index).with([{
+      stub_index = stub("Rummageable::Index")
+      Rummageable::Index.expects(:new).returns(stub_index)
+      stub_index.expects(:add_batch).with([{
           "title" => recommended_link.title,
           "description" => recommended_link.description,
           "format" => recommended_link.format,
@@ -30,7 +32,9 @@ module RecommendedLinks
         RecommendedLink.new("Second","","",[])
       ]
 
-      Rummageable.expects(:index).with(recommended_links.map { |l| l.to_index })
+      stub_index = stub("Rummageable::Index")
+      Rummageable::Index.expects(:new).returns(stub_index)
+      stub_index.expects(:add_batch).with(recommended_links.map { |l| l.to_index })
 
       Indexer.new.index(recommended_links)
     end
@@ -39,8 +43,10 @@ module RecommendedLinks
       deleted = [DeletedLink.new("http://delete.me/1"), DeletedLink.new("http://delete.me/2")]
 
       s = sequence('deletion')
-      Rummageable.expects(:delete).with("http://delete.me/1").in_sequence(s)
-      Rummageable.expects(:delete).with("http://delete.me/2").in_sequence(s)
+      stub_index = stub("Rummageable::Index")
+      Rummageable::Index.expects(:new).with('http://rummager.dev.gov.uk', '/mainstream').returns(stub_index)
+      stub_index.expects(:delete).with("http://delete.me/1").in_sequence(s)
+      stub_index.expects(:delete).with("http://delete.me/2").in_sequence(s)
 
       Indexer.new.remove(deleted)
     end
@@ -54,14 +60,16 @@ module RecommendedLinks
         "recommended-link", "Business", "test-index"
       )
 
-      Rummageable.expects(:index).with([{
+      stub_index = stub("Rummageable::Index")
+      Rummageable::Index.expects(:new).with('http://rummager.dev.gov.uk', '/test-index').returns(stub_index)
+      stub_index.expects(:add_batch).with([{
           "title" => recommended_link.title,
           "description" => recommended_link.description,
           "format" => recommended_link.format,
           "link" => recommended_link.url,
           "indexable_content" => recommended_link.match_phrases.join(", "),
           "section" => recommended_link.section
-        }], '/test-index')
+        }])
 
       Indexer.new.index([recommended_link])
     end
@@ -71,7 +79,10 @@ module RecommendedLinks
         "http://example.com/delete-me",
         "test-index"
         )
-      Rummageable.expects(:delete).with("http://example.com/delete-me", '/test-index')
+
+      stub_index = stub("Rummageable::Index")
+      Rummageable::Index.expects(:new).with('http://rummager.dev.gov.uk', '/test-index').returns(stub_index)
+      stub_index.expects(:delete).with("http://example.com/delete-me")
 
       Indexer.new.remove([deleted_link])
     end


### PR DESCRIPTION
This app was using a very old version of rummageable - 0.6.1.  The API of rummageable has
been updated since this version, so we also need to rework the code a fair bit.

We need to upgrade rummageable because the old version didn't allow the
host to talk to to find rummager to be configured, and the name has
changed (from "search" to "rummager").  The new version does allow this
to be changed.  We recently removed "search" as an alias for "rummager", so
until this is deployed, deploying recommended links won't populate the index
with the recommended links.
