### PR TITLE
Bump gds api adapters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'http://rubygems.org'
 gem 'plek', '1.3.1'
 gem 'rummageable', "1.2.0"
 gem 'rake', '0.9.2'
-gem 'gds-api-adapters', '10.2.0'
+gem 'gds-api-adapters', '20.1.1'
 
 group :test do
   gem 'mocha', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,25 +3,36 @@ GEM
   specs:
     PriorityQueue (0.1.2)
     ansi (1.4.1)
-    gds-api-adapters (10.2.0)
+    domain_name (0.5.24)
+      unf (>= 0.0.5, < 1.0.0)
+    gds-api-adapters (20.1.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek
-      rest-client (~> 1.6.3)
+      rack-cache
+      rest-client (~> 1.8.0)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     link_header (0.0.8)
     lrucache (0.1.4)
       PriorityQueue (~> 0.1.2)
     metaclass (0.0.1)
-    mime-types (1.19)
+    mime-types (2.6.1)
     mocha (0.10.0)
       metaclass (~> 0.0.1)
     multi_json (1.11.1)
+    netrc (0.10.3)
     null_logger (0.0.1)
     plek (1.3.1)
+    rack (1.6.4)
+    rack-cache (1.2)
+      rack (>= 0.4)
     rake (0.9.2)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     rummageable (1.2.0)
       multi_json
       null_logger
@@ -30,12 +41,15 @@ GEM
     test-unit (2.4.3)
     turn (0.8.3)
       ansi
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  gds-api-adapters (= 10.2.0)
+  gds-api-adapters (= 20.1.1)
   mocha
   plek (= 1.3.1)
   rake (= 0.9.2)

--- a/test/unit/parser_test.rb
+++ b/test/unit/parser_test.rb
@@ -57,7 +57,7 @@ module RecommendedLinks
     end
 
     test "Can parse the included data file" do
-      recommended_links = Parser.new(csv_real_file, "recommended-link").links
+      Parser.new(csv_real_file, "recommended-link").links
     end
 
     test "Can handle trailing spaces in header row" do


### PR DESCRIPTION
This changes the user agent to include the app
name in API requests.

https://trello.com/c/qkHdtob4/247-bump-gds-api-adapters-everywhere-it-s-used-to-include-user-agent-information
